### PR TITLE
Addition of poi-ooxml-schemas for tika parser

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.github.lafa.tikaNoExternal</groupId>
     <artifactId>tika-parent</artifactId>
-    <version>1.0.10</version>
+    <version>1.0.11</version>
     <relativePath>tika-parent/pom.xml</relativePath>
   </parent>
 

--- a/tika-app/pom.xml
+++ b/tika-app/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>com.github.lafa.tikaNoExternal</groupId>
     <artifactId>tika-parent</artifactId>
-    <version>1.0.10</version>
+    <version>1.0.11</version>
     <relativePath>../tika-parent/pom.xml</relativePath>
   </parent>
 

--- a/tika-batch/pom.xml
+++ b/tika-batch/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>com.github.lafa.tikaNoExternal</groupId>
     <artifactId>tika-parent</artifactId>
-    <version>1.0.10</version>
+    <version>1.0.11</version>
     <relativePath>../tika-parent/pom.xml</relativePath>
   </parent>
 

--- a/tika-bundle/pom.xml
+++ b/tika-bundle/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>com.github.lafa.tikaNoExternal</groupId>
     <artifactId>tika-parent</artifactId>
-    <version>1.0.10</version>
+    <version>1.0.11</version>
     <relativePath>../tika-parent/pom.xml</relativePath>
   </parent>
 

--- a/tika-core/pom.xml
+++ b/tika-core/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>com.github.lafa.tikaNoExternal</groupId>
     <artifactId>tika-parent</artifactId>
-    <version>1.0.10</version>
+    <version>1.0.11</version>
     <relativePath>../tika-parent/pom.xml</relativePath>
   </parent>
   

--- a/tika-dotnet/pom.xml
+++ b/tika-dotnet/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>com.github.lafa.tikaNoExternal</groupId>
     <artifactId>tika-parent</artifactId>
-    <version>1.0.10</version>
+    <version>1.0.11</version>
     <relativePath>../tika-parent/pom.xml</relativePath>
   </parent>
 

--- a/tika-example/pom.xml
+++ b/tika-example/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>com.github.lafa.tikaNoExternal</groupId>
     <artifactId>tika-parent</artifactId>
-    <version>1.0.10</version>
+    <version>1.0.11</version>
     <relativePath>../tika-parent/pom.xml</relativePath>
   </parent>
 

--- a/tika-external/pom.xml
+++ b/tika-external/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.github.lafa.tikaNoExternal</groupId>
     <artifactId>tika-parent</artifactId>
-    <version>1.0.10</version>
+    <version>1.0.11</version>
     <relativePath>../tika-parent/pom.xml</relativePath>
   </parent>
   

--- a/tika-java7/pom.xml
+++ b/tika-java7/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>com.github.lafa.tikaNoExternal</groupId>
     <artifactId>tika-parent</artifactId>
-    <version>1.0.10</version>
+    <version>1.0.11</version>
     <relativePath>../tika-parent/pom.xml</relativePath>
   </parent>
 

--- a/tika-langdetect/pom.xml
+++ b/tika-langdetect/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>com.github.lafa.tikaNoExternal</groupId>
     <artifactId>tika-parent</artifactId>
-    <version>1.0.10</version>
+    <version>1.0.11</version>
     <relativePath>../tika-parent/pom.xml</relativePath>
   </parent>
 

--- a/tika-parent/pom.xml
+++ b/tika-parent/pom.xml
@@ -33,7 +33,7 @@
 
   <groupId>com.github.lafa.tikaNoExternal</groupId>
   <artifactId>tika-parent</artifactId>
-  <version>1.0.10</version>
+  <version>1.0.11</version>
   <packaging>pom</packaging>
 
   <name>Apache Tika parent</name>

--- a/tika-parsers/pom.xml
+++ b/tika-parsers/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>com.github.lafa.tikaNoExternal</groupId>
     <artifactId>tika-parent</artifactId>
-    <version>1.0.10</version>
+    <version>1.0.11</version>
     <relativePath>../tika-parent/pom.xml</relativePath>
   </parent>
 
@@ -178,6 +178,11 @@
           <artifactId>xml-apis</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.poi</groupId>
+    <artifactId>poi-ooxml-schemas</artifactId>
+    <version>4.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.ccil.cowan.tagsoup</groupId>

--- a/tika-serialization/pom.xml
+++ b/tika-serialization/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>com.github.lafa.tikaNoExternal</groupId>
     <artifactId>tika-parent</artifactId>
-    <version>1.0.10</version>
+    <version>1.0.11</version>
     <relativePath>../tika-parent/pom.xml</relativePath>
   </parent>
 

--- a/tika-server/pom.xml
+++ b/tika-server/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>com.github.lafa.tikaNoExternal</groupId>
     <artifactId>tika-parent</artifactId>
-    <version>1.0.10</version>
+    <version>1.0.11</version>
     <relativePath>../tika-parent/pom.xml</relativePath>
   </parent>
 

--- a/tika-translate/pom.xml
+++ b/tika-translate/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>com.github.lafa.tikaNoExternal</groupId>
     <artifactId>tika-parent</artifactId>
-    <version>1.0.10</version>
+    <version>1.0.11</version>
     <relativePath>../tika-parent/pom.xml</relativePath>
   </parent>
 

--- a/tika-xmp/pom.xml
+++ b/tika-xmp/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>com.github.lafa.tikaNoExternal</groupId>
     <artifactId>tika-parent</artifactId>
-    <version>1.0.10</version>
+    <version>1.0.11</version>
     <relativePath>../tika-parent/pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
This PR adds dependency poi-ooxml-schemas to the existing poi 3.17 version which solves the yjava_jetty.out error message : java.lang.NoSuchMethodException: org.openxmlformats.schemas.wordprocessingml.x2006.main.impl.CTPictureBaseImpl.<init>(org.apache.xmlbeans.SchemaType, boolean) 