### PR TITLE
Update version of tag chowder to 2.0.3

### DIFF
--- a/tika-app/pom.xml
+++ b/tika-app/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>com.github.lafa.tikaNoExternal</groupId>
     <artifactId>tika-parent</artifactId>
-    <version>1.0.12</version>
+    <version>1.0.13</version>
     <relativePath>../tika-parent/pom.xml</relativePath>
   </parent>
 

--- a/tika-batch/pom.xml
+++ b/tika-batch/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>com.github.lafa.tikaNoExternal</groupId>
     <artifactId>tika-parent</artifactId>
-    <version>1.0.12</version>
+    <version>1.0.13</version>
     <relativePath>../tika-parent/pom.xml</relativePath>
   </parent>
 

--- a/tika-bundle/pom.xml
+++ b/tika-bundle/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>com.github.lafa.tikaNoExternal</groupId>
     <artifactId>tika-parent</artifactId>
-    <version>1.0.12</version>
+    <version>1.0.13</version>
     <relativePath>../tika-parent/pom.xml</relativePath>
   </parent>
 

--- a/tika-core/pom.xml
+++ b/tika-core/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>com.github.lafa.tikaNoExternal</groupId>
     <artifactId>tika-parent</artifactId>
-    <version>1.0.12</version>
+    <version>1.0.13</version>
     <relativePath>../tika-parent/pom.xml</relativePath>
   </parent>
   

--- a/tika-dotnet/pom.xml
+++ b/tika-dotnet/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>com.github.lafa.tikaNoExternal</groupId>
     <artifactId>tika-parent</artifactId>
-    <version>1.0.12</version>
+    <version>1.0.13</version>
     <relativePath>../tika-parent/pom.xml</relativePath>
   </parent>
 

--- a/tika-example/pom.xml
+++ b/tika-example/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>com.github.lafa.tikaNoExternal</groupId>
     <artifactId>tika-parent</artifactId>
-    <version>1.0.12</version>
+    <version>1.0.13</version>
     <relativePath>../tika-parent/pom.xml</relativePath>
   </parent>
 

--- a/tika-external/pom.xml
+++ b/tika-external/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.github.lafa.tikaNoExternal</groupId>
     <artifactId>tika-parent</artifactId>
-    <version>1.0.12</version>
+    <version>1.0.13</version>
     <relativePath>../tika-parent/pom.xml</relativePath>
   </parent>
   

--- a/tika-java7/pom.xml
+++ b/tika-java7/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>com.github.lafa.tikaNoExternal</groupId>
     <artifactId>tika-parent</artifactId>
-    <version>1.0.12</version>
+    <version>1.0.13</version>
     <relativePath>../tika-parent/pom.xml</relativePath>
   </parent>
 

--- a/tika-langdetect/pom.xml
+++ b/tika-langdetect/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>com.github.lafa.tikaNoExternal</groupId>
     <artifactId>tika-parent</artifactId>
-    <version>1.0.12</version>
+    <version>1.0.13</version>
     <relativePath>../tika-parent/pom.xml</relativePath>
   </parent>
 

--- a/tika-parent/pom.xml
+++ b/tika-parent/pom.xml
@@ -33,7 +33,7 @@
 
   <groupId>com.github.lafa.tikaNoExternal</groupId>
   <artifactId>tika-parent</artifactId>
-  <version>1.0.12</version>
+  <version>1.0.13</version>
   <packaging>pom</packaging>
 
   <name>Apache Tika parent</name>

--- a/tika-parsers/pom.xml
+++ b/tika-parsers/pom.xml
@@ -187,7 +187,7 @@
     <dependency>
         <groupId>com.github.lafa.tagchowder</groupId>
         <artifactId>tagchowder.core</artifactId>
-        <version>2.0.2</version>
+        <version>2.0.3</version>
     </dependency>
     <dependency>
       <groupId>org.ow2.asm</groupId>

--- a/tika-parsers/pom.xml
+++ b/tika-parsers/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>com.github.lafa.tikaNoExternal</groupId>
     <artifactId>tika-parent</artifactId>
-    <version>1.0.12</version>
+    <version>1.0.13</version>
     <relativePath>../tika-parent/pom.xml</relativePath>
   </parent>
 

--- a/tika-serialization/pom.xml
+++ b/tika-serialization/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>com.github.lafa.tikaNoExternal</groupId>
     <artifactId>tika-parent</artifactId>
-    <version>1.0.12</version>
+    <version>1.0.13</version>
     <relativePath>../tika-parent/pom.xml</relativePath>
   </parent>
 

--- a/tika-server/pom.xml
+++ b/tika-server/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>com.github.lafa.tikaNoExternal</groupId>
     <artifactId>tika-parent</artifactId>
-    <version>1.0.12</version>
+    <version>1.0.13</version>
     <relativePath>../tika-parent/pom.xml</relativePath>
   </parent>
 

--- a/tika-translate/pom.xml
+++ b/tika-translate/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>com.github.lafa.tikaNoExternal</groupId>
     <artifactId>tika-parent</artifactId>
-    <version>1.0.12</version>
+    <version>1.0.13</version>
     <relativePath>../tika-parent/pom.xml</relativePath>
   </parent>
 

--- a/tika-xmp/pom.xml
+++ b/tika-xmp/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>com.github.lafa.tikaNoExternal</groupId>
     <artifactId>tika-parent</artifactId>
-    <version>1.0.12</version>
+    <version>1.0.13</version>
     <relativePath>../tika-parent/pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
This is for the changes in https://github.com/lafaspot/tagchowder/pull/19/