### PR TITLE
Switch tika to use latest tagchowder-2.0.22

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>com.github.lafa.tikaNoExternal</groupId>
     <artifactId>tika-parent</artifactId>
-    <version>1.0.17</version>
+    <version>1.0.18</version>
     <relativePath>tika-parent/pom.xml</relativePath>
   </parent>
 

--- a/tika-app/pom.xml
+++ b/tika-app/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>com.github.lafa.tikaNoExternal</groupId>
     <artifactId>tika-parent</artifactId>
-    <version>1.0.17</version>
+    <version>1.0.18</version>
     <relativePath>../tika-parent/pom.xml</relativePath>
   </parent>
 

--- a/tika-batch/pom.xml
+++ b/tika-batch/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>com.github.lafa.tikaNoExternal</groupId>
     <artifactId>tika-parent</artifactId>
-    <version>1.0.17</version>
+    <version>1.0.18</version>
     <relativePath>../tika-parent/pom.xml</relativePath>
   </parent>
 

--- a/tika-core/pom.xml
+++ b/tika-core/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>com.github.lafa.tikaNoExternal</groupId>
     <artifactId>tika-parent</artifactId>
-    <version>1.0.17</version>
+    <version>1.0.18</version>
     <relativePath>../tika-parent/pom.xml</relativePath>
   </parent>
   

--- a/tika-example/pom.xml
+++ b/tika-example/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>com.github.lafa.tikaNoExternal</groupId>
     <artifactId>tika-parent</artifactId>
-    <version>1.0.17</version>
+    <version>1.0.18</version>
     <relativePath>../tika-parent/pom.xml</relativePath>
   </parent>
 

--- a/tika-external/pom.xml
+++ b/tika-external/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.github.lafa.tikaNoExternal</groupId>
     <artifactId>tika-parent</artifactId>
-    <version>1.0.17</version>
+    <version>1.0.18</version>
     <relativePath>../tika-parent/pom.xml</relativePath>
   </parent>
   

--- a/tika-java7/pom.xml
+++ b/tika-java7/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>com.github.lafa.tikaNoExternal</groupId>
     <artifactId>tika-parent</artifactId>
-    <version>1.0.17</version>
+    <version>1.0.18</version>
     <relativePath>../tika-parent/pom.xml</relativePath>
   </parent>
 

--- a/tika-langdetect/pom.xml
+++ b/tika-langdetect/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>com.github.lafa.tikaNoExternal</groupId>
     <artifactId>tika-parent</artifactId>
-    <version>1.0.17</version>
+    <version>1.0.18</version>
     <relativePath>../tika-parent/pom.xml</relativePath>
   </parent>
 

--- a/tika-parent/pom.xml
+++ b/tika-parent/pom.xml
@@ -33,7 +33,7 @@
 
   <groupId>com.github.lafa.tikaNoExternal</groupId>
   <artifactId>tika-parent</artifactId>
-  <version>1.0.17</version>
+  <version>1.0.18</version>
   <packaging>pom</packaging>
 
   <name>Apache Tika parent</name>
@@ -580,14 +580,4 @@
 			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
 		</repository>
 	</distributionManagement>
-    <repositories>
-        <repository>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <id>jcenter</id>
-            <name>bintray</name>
-            <url>https://jcenter.bintray.com</url>
-        </repository>
-    </repositories>
 </project>

--- a/tika-parsers/pom.xml
+++ b/tika-parsers/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>com.github.lafa.tikaNoExternal</groupId>
     <artifactId>tika-parent</artifactId>
-    <version>1.0.17</version>
+    <version>1.0.18</version>
     <relativePath>../tika-parent/pom.xml</relativePath>
   </parent>
 
@@ -187,7 +187,7 @@
     <dependency>
         <groupId>com.yahoo.tagchowder</groupId>
         <artifactId>tagchowder.core</artifactId>
-        <version>2.0.17</version>
+        <version>2.0.22</version>
     </dependency>
     <dependency>
       <groupId>org.ow2.asm</groupId>

--- a/tika-serialization/pom.xml
+++ b/tika-serialization/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>com.github.lafa.tikaNoExternal</groupId>
     <artifactId>tika-parent</artifactId>
-    <version>1.0.17</version>
+    <version>1.0.18</version>
     <relativePath>../tika-parent/pom.xml</relativePath>
   </parent>
 

--- a/tika-server/pom.xml
+++ b/tika-server/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>com.github.lafa.tikaNoExternal</groupId>
     <artifactId>tika-parent</artifactId>
-    <version>1.0.17</version>
+    <version>1.0.18</version>
     <relativePath>../tika-parent/pom.xml</relativePath>
   </parent>
 

--- a/tika-translate/pom.xml
+++ b/tika-translate/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>com.github.lafa.tikaNoExternal</groupId>
     <artifactId>tika-parent</artifactId>
-    <version>1.0.17</version>
+    <version>1.0.18</version>
     <relativePath>../tika-parent/pom.xml</relativePath>
   </parent>
 

--- a/tika-xmp/pom.xml
+++ b/tika-xmp/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>com.github.lafa.tikaNoExternal</groupId>
     <artifactId>tika-parent</artifactId>
-    <version>1.0.17</version>
+    <version>1.0.18</version>
     <relativePath>../tika-parent/pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
1. Switch tika to use latest tagchowder-2.0.22
2. Remove downloading artifacts from bintray/jcenter
3. Bump up pom.xml version

Current tika using tagchowder-2.0.17 downloaded from Bintray (EOL now)
New changes move tika to use tagchowder-2.0.22 downloaded from Maven Central

```
Difference between  tagchowder-2.0.17 and tagchowder-2.0.18
Add AMP validation features to support literal attribute value, e.g [].
https://github.com/yahoo/tagchowder/commit/11925a4b5d611a26a13726e45585490f26ce7b7e

Difference between  tagchowder-2.0.18 and tagchowder-2.0.22 is 
Migrate from bintray to Maven Central
```